### PR TITLE
Allows multiple roles on authenticated routes

### DIFF
--- a/backend/src/middlewares/auth-required.js
+++ b/backend/src/middlewares/auth-required.js
@@ -3,7 +3,7 @@ import jwt from 'jsonwebtoken'
 const UNAUTHORIZED_MESSAGE = 'Unauthorized request, check your credentials.'
 const FORBIDDEN_MESSAGE = 'Forbidden'
 
-export function authRequired (role) {
+export function authRequired (...roles) {
   return async function (req, res, next) {
     const token = req.headers['x-access-token']
     if (!token) return res.status(401).send({ auth: false, message: UNAUTHORIZED_MESSAGE })
@@ -15,7 +15,7 @@ export function authRequired (role) {
         return res.status(401).send({ auth: false, message: UNAUTHORIZED_MESSAGE })
       }
 
-      if (role && auth.role !== role) {
+      if (roles.length > 0 && !roles.includes(auth.role)) {
         return res.status(403).send({ auth: true, message: FORBIDDEN_MESSAGE })
       }
 


### PR DESCRIPTION
Com essa mudança o middleware de autenticação pode ser chamado para mais de uma `role` o uso seria

```javascript
router.get('/private/route', authRequired('admin', 'leader'), (req, res, next) =>
```

O uso sem passar parâmetros para rotas que basta o usuário estar autenticado continua sendo válido.