### PR TITLE
HotFix - Filtro em Lambda aplicado errôneamente

### DIFF
--- a/lambdas/cesta-basica-report-factory/data.js
+++ b/lambdas/cesta-basica-report-factory/data.js
@@ -32,7 +32,7 @@ async function voucherData ({
     matchDonation.siteId = siteId
   }
   if (status) {
-    matchVoucher.push({ $eq: [ "$status", status ] })
+    matchDonation.status = status
   }
   if (listDonationId) {
     if (!Array.isArray(listDonationId)) {


### PR DESCRIPTION
### Comportamento Correto ✔️ 
Ao filtrar utilizar os filtros para geração de relatório de cartões ("`vouchers`"), o usuário seleciona os `status` do Borderô ("`donation`").

### Comportamento Errôneo ❌ 
O `status` passado para geração do relatório de Cartões era aplicado como filtro no `status` do cartão, ao invés do `status` do Borderô .

### Solução 👍 
Aplicação do filtro no estágio de pipeline da agregação em que é feita a filtragem por `status` da `donation` 