### PR TITLE
fix: export button had behavior changed

### DIFF
--- a/frontend/src/pages/Export/Form/index.js
+++ b/frontend/src/pages/Export/Form/index.js
@@ -248,12 +248,12 @@ function ExportForm({ store, dispatch }) {
         <HeaderWithGoBack onGoBackClick={handleGoBack} title={filter} message={selected} />
         {renderFilterComponent()}
       </div>
-      <div>
+      <div className="exportForm-footer">
         <Button
           size={ButtonTypes.LARGE}
           message={exportFirstLetterCapitalized}
           handleClick={handleSubmit}
-          disable={enableButton()}
+          disable={selected === unit || selected === leaderStr ? false : enableButton()}
         />
       </div>
     </div>


### PR DESCRIPTION
Estória: pontuada por Eldo (30.04.2020)

- Tela Filtro de Exportação: ao escolher os filtros de exportação Unidade ou Líder, o botão de exportar ficará ativo sem a necessidade de escolher um estado/cidade.

![filtro-exportar1-unidade](https://user-images.githubusercontent.com/60357934/80725873-0800df80-8ada-11ea-9741-f9525ae0e6e0.jpg)

![filtro-exportar2-lider](https://user-images.githubusercontent.com/60357934/80725882-0afbd000-8ada-11ea-8e00-77487db114b2.jpg)
